### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ env.PR_TOKEN || github.token }}
 
       - name: +Mᐁ includes
-        uses: devlooped/actions-includes@v1
+        uses: devlooped/actions-includes@v2
 
       - name: 📝 OSMF EULA
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ env:
   Configuration: Release
   PackOnBuild: true
   GeneratePackageOnBuild: true
-  VersionLabel: ${{ github.ref }}
+  VersionLabel: refs/tags/${{ github.event.release.tag_name }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   MSBUILDTERMINALLOGGER: auto
   SLEET_FEED_URL: https://api.nuget.org/v3/index.json
@@ -43,6 +43,16 @@ jobs:
         with:
           name: logs
           path: '*.binlog'
+
+      - name: ✅ validate
+        shell: pwsh
+        working-directory: bin
+        run: |
+          $invalid = Get-ChildItem -File -Filter "*.42.42*.nupkg"
+          if ($invalid) {
+            Write-Error "Found dev/local packages with disallowed 42.42* version prefix:`n$($invalid.Name -join "`n")"
+            exit 1
+          }
 
       - name: 🚀 nuget
         env:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: 'triage'
 on:
   schedule:
-    - cron: '42 0 * * *'
+    - cron: '42 0 1,15 * *'
 
   workflow_dispatch:
     # Manual triggering through the GitHub UI, API, or CLI

--- a/.netconfig
+++ b/.netconfig
@@ -71,21 +71,21 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 7c1c6e615b5785e0ac9db33cb17343d6c1de16ff
+	sha = d571412f07b0fb3c40023dc906f64906d7ed2b46
 
-	etag = 5e6a10be141ee629201bfad01eae09b5c36a67f541ec7ab411ae400b5d73de1d
+	etag = ab627107749577bb619b024aff93027359b66b4c3f5a85a36b235e428387cd17
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 7f5f9ee9f362f7e8f951d618f8f799033550e687
+	sha = 0ca5fd11125cd10c51b4433a86917c06ff1ae839
 
-	etag = c60411d1aa4e98e7f69e2d34cbccb8eb7e387ec11f6f8e78ee8d8b92122d7025
+	etag = ac46ffdcef820bbc6bd32378aef25ff79713196e0a5696791abb3a804e06e4d8
 	weak
 [file ".github/workflows/triage.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
+	sha = 5ee8c91c8d9e8c0ee739fe1ec877f36c15a4aff0
 
-	etag = 152cd3a559c08da14d1da12a5262ba1d2e0ed6bed6d2eabf5bd209b0c35d8a75
+	etag = b19dc36058fc7d385cb5795c9e0860c11b9d027c57cb2a5e6a112e692c6884c1
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
@@ -95,9 +95,9 @@
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
-	sha = 0f7f7f7e8a29de9b535676f75fe7c67e629a5e8c
+	sha = 320a5c5710f269ccb038b5e74146fed8b5a114ae
 
-	etag = 0ccae83fc51f400bfd7058170bfec7aba11455e24a46a0d7e6a358da6486e255
+	etag = 9872addf980da78842d42e70e72f90fb10ba52c1c2ccddc8aa9a2b83e0005679
 	weak
 [file "_config.yml"]
 	url = https://github.com/devlooped/oss/blob/main/_config.yml
@@ -119,15 +119,15 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 6e2438919e108aeb75106dc0737c45f5e55d5f42
+	sha = 59861ddd1e330f3da410652b4c7fc6585726c0cf
 
-	etag = f1d6384abf18d8d891ce5e835a10c73fe029c42151374be96d7e4af43d189c65
+	etag = 1561f1be53cc25ac0cd85a06b3f65d69764b174d0f60bf72ca2f8fc70573b75e
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = c67952501337303eda0fb8b340cb7606666abd8f
+	sha = 59861ddd1e330f3da410652b4c7fc6585726c0cf
 
-	etag = cb83faed0cc8b930a7b6bdc61bea03a54059858cf04353e55fee94d9e3ae0fad
+	etag = cb1f7a3e5bf85e7307407b7b6d8b9869330e2191a2317ccf6218a552e5890b08
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
@@ -137,9 +137,9 @@
 	weak
 [file "src/dotnet-env/DotnetMuxer.cs"]
 	url = https://github.com/devlooped/catbag/blob/main/System/DotnetMuxer.cs
-	sha = b8556d40c2e669ae6455fa19948133e1e3c87306
+	sha = 46b1f084ace577a280d9db0ab207a81df27c292e
 
-	etag = 6f3264c622a89bc84836de0b1755be60967ffb224c4a28dc0b6744448ff1e5b4
+	etag = 1dee7e7379a7bc3e3b44bbac5512050ccae79c9bf3abdd4d04e87114842d5e46
 	weak
 [file ".github/workflows/dotnet-env.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -3,3 +3,4 @@
 -m:1
 -v:m
 -clp:Summary;ForceNoAlign
+-p:WarnOnPackingNonPackableProject=false

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,6 @@ OPTIONS:
 [![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
 [![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)
 [![Thomas Bolon](https://avatars.githubusercontent.com/u/127185?u=7f50babfc888675e37feb80851a4e9708f573386&v=4&s=39 "Thomas Bolon")](https://github.com/tbolon)
-[![Kori Francis](https://avatars.githubusercontent.com/u/67574?u=3991fb983e1c399edf39aebc00a9f9cd425703bd&v=4&s=39 "Kori Francis")](https://github.com/kfrancis)
 [![Reuben Swartz](https://avatars.githubusercontent.com/u/724704?u=2076fe336f9f6ad678009f1595cbea434b0c5a41&v=4&s=39 "Reuben Swartz")](https://github.com/rbnswartz)
 [![Jacob Foshee](https://avatars.githubusercontent.com/u/480334?v=4&s=39 "Jacob Foshee")](https://github.com/jfoshee)
 [![](https://avatars.githubusercontent.com/u/33566379?u=bf62e2b46435a267fa246a64537870fd2449410f&v=4&s=39 "")](https://github.com/Mrxx99)
@@ -86,6 +85,7 @@ OPTIONS:
 [![Andrew Grant](https://avatars.githubusercontent.com/devlooped-user?s=39 "Andrew Grant")](https://github.com/wizardness)
 [![eska-gmbh](https://avatars.githubusercontent.com/devlooped-team?s=39 "eska-gmbh")](https://github.com/eska-gmbh)
 [![Geodata AS](https://avatars.githubusercontent.com/u/5946299?v=4&s=39 "Geodata AS")](https://github.com/geodata-no)
+[![Jiri Slachta](https://avatars.githubusercontent.com/u/6891947?u=802cfeb13b070d04c53269fc662b0d58963480dd&v=4&s=39 "Jiri Slachta")](https://github.com/jslachta)
 
 
 <!-- sponsors.md -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,10 +25,12 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
-    <!-- Pick src-level readme+icon automatically -->
+    <!-- Pick src-level readme+icon automatically (icon.png preferred, logo.png fallback) -->
+    <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)logo.png')">logo.png</PackageIcon>
     <PackageIcon Condition="Exists('$(MSBuildThisFileDirectory)icon.png')">icon.png</PackageIcon>
     <PackageReadmeFile Condition="'$(PackReadme)' != 'false' and Exists('$(MSBuildThisFileDirectory)readme.md')">readme.md</PackageReadmeFile>
     <!-- Pick project-level readme+icon overrides automatically -->
+    <PackageIcon Condition="Exists('$(MSBuildProjectDirectory)\logo.png')">logo.png</PackageIcon>
     <PackageIcon Condition="Exists('$(MSBuildProjectDirectory)\icon.png')">icon.png</PackageIcon>
     <PackageReadmeFile Condition="'$(PackReadme)' != 'false' and Exists('$(MSBuildProjectDirectory)\readme.md')">readme.md</PackageReadmeFile>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -39,7 +39,14 @@
     <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
   </PropertyGroup>
 
-  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)')"/>
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)') And '$(NuGetize)' != 'true'" />
+
+  <!-- Fix for hardcoded assumption in SDK: <GenerateStaticWebAssetsManifest Source="$(PackageId)" -->
+  <Target Name="EnsureStaticWebAssetsSource" BeforeTargets="GenerateStaticWebAssetsManifest">
+    <PropertyGroup>
+      <PackageId Condition="'$(PackageId)' == ''">$(MSBuildProjectName)</PackageId>
+    </PropertyGroup>
+  </Target>
 
   <PropertyGroup>
     <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->
@@ -56,7 +63,12 @@
     <None Update="@(None -> WithMetadataValue('Filename', 'icon'))" 
           Pack="true" PackagePath="%(Filename)%(Extension)" 
           CopyToOutputDirectory="Never"
-          Condition="'$(PackageIcon)' != ''" />
+          Condition="'$(PackageIcon)' == 'icon.png'" />
+
+    <None Update="@(None -> WithMetadataValue('Filename', 'logo'))" 
+          Pack="true" PackagePath="%(Filename)%(Extension)" 
+          CopyToOutputDirectory="Never"
+          Condition="'$(PackageIcon)' == 'logo.png'" />
 
     <None Update="@(None -> WithMetadataValue('Filename', 'readme'))" 
           Pack="true" PackagePath="%(Filename)%(Extension)" 
@@ -64,10 +76,10 @@
           Condition="'$(PackReadme)' != 'false' and '$(PackageReadmeFile)' != ''" />
     
     <!-- src-level will need explicit inclusion -->
-    <None Include="$(MSBuildThisFileDirectory)icon.png" Link="icon.png" Visible="false" 
-          Pack="true" PackagePath="%(Filename)%(Extension)"
+    <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Link="$(PackageIcon)" Visible="false" 
+          Pack="true" PackagePath="$(PackageIcon)"
           CopyToOutputDirectory="Never"
-          Condition="Exists('$(MSBuildThisFileDirectory)icon.png') and !Exists('$(MSBuildProjectDirectory)\icon.png')" />
+          Condition="'$(PackageIcon)' != '' and Exists('$(MSBuildThisFileDirectory)$(PackageIcon)') and !Exists('$(MSBuildProjectDirectory)\$(PackageIcon)')" />
 
     <None Include="$(MSBuildThisFileDirectory)readme.md" Link="readme.md"  
           Pack="true" PackagePath="%(Filename)%(Extension)"

--- a/src/dotnet-env/DotnetMuxer.cs
+++ b/src/dotnet-env/DotnetMuxer.cs
@@ -50,6 +50,7 @@ namespace System
                 return mainModuleFullPath;
             }
 
+            // Framework-dependent / R2R: muxer is three levels above the shared runtime.
             // The currently running process may not be dotnet(.exe). For example,
             // it might be "testhost(.exe)" when running tests.
             // In this case, we can get the location where the CLR is installed,
@@ -58,8 +59,22 @@ namespace System
             var candidateDotNetExePath = Path.Combine(runtimeDirectory, "..", "..", "..", expectedFileName);
             if (File.Exists(candidateDotNetExePath))
             {
-                var normalizedPath = Path.GetFullPath(candidateDotNetExePath);
-                return normalizedPath;
+                return Path.GetFullPath(candidateDotNetExePath);
+            }
+
+            // Native AOT (e.g. dnx go default publish) reports the app dir as the runtime
+            // directory, so that walk is wrong — use DOTNET_HOST_PATH / DOTNET_ROOT.
+            if (Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
+                && File.Exists(host))
+            {
+                return host;
+            }
+
+            if (Environment.GetEnvironmentVariable("DOTNET_ROOT") is { Length: > 0 } root)
+            {
+                var fromRoot = Path.Combine(root, expectedFileName);
+                if (File.Exists(fromRoot))
+                    return fromRoot;
             }
 
             return null;


### PR DESCRIPTION
# devlooped/oss

- Update cron schedule in triage workflow https://github.com/devlooped/oss/commit/5ee8c91
- Allow logo.png as a PackageIcon fallback for nugetizer and SDK pack. https://github.com/devlooped/oss/commit/59861dd
- Update actions-includes version to v2 https://github.com/devlooped/oss/commit/d571412
- feat: add validation step to check for disallowed package versions in publish workflow https://github.com/devlooped/oss/commit/0ca5fd1
- Disable warning on packing non-packable projects https://github.com/devlooped/oss/commit/320a5c5

# devlooped/catbag

- Fall back to DOTNET_HOST_PATH/DOTNET_ROOT when muxer walk fails https://github.com/devlooped/catbag/commit/46b1f08